### PR TITLE
Add web environment configuration

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,2 @@
+# Absolute path to the SQLite database written by the fetchlinks ingestion app.
+FETCHLINKS_DB=/var/lib/fetchlinks/fetchlinks.db

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/web/README.md
+++ b/web/README.md
@@ -6,6 +6,10 @@ This is the new Next.js TypeScript application scaffold for the Fetchlinks web U
 
 The scaffold targets Node 24.15 or newer with npm 11.12 or newer.
 
+## Environment
+
+Copy `.env.example` to `.env.local` for local development and set `FETCHLINKS_DB` to the absolute path of the SQLite database written by the fetchlinks ingestion app. The web app treats this database as read-only.
+
 ## Commands
 
 ```bash

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit --project tsconfig.typecheck.json",
     "test": "vitest run"
   },
   "dependencies": {

--- a/web/src/server/config.test.ts
+++ b/web/src/server/config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { ConfigError, loadAppConfig, toReadOnlySqliteUri } from "./config";
+
+describe("loadAppConfig", () => {
+  it("requires FETCHLINKS_DB", () => {
+    expect(() => loadAppConfig({})).toThrowError(ConfigError);
+    expect(() => loadAppConfig({})).toThrowError(/FETCHLINKS_DB is required/);
+  });
+
+  it("rejects an empty FETCHLINKS_DB", () => {
+    expect(() => loadAppConfig({ FETCHLINKS_DB: "   " })).toThrowError(
+      /FETCHLINKS_DB is required/,
+    );
+  });
+
+  it("rejects a relative FETCHLINKS_DB", () => {
+    expect(() =>
+      loadAppConfig({ FETCHLINKS_DB: "data/fetchlinks.db" }),
+    ).toThrowError(/FETCHLINKS_DB must be an absolute path/);
+  });
+
+  it("loads the configured database path and read-only SQLite URI", () => {
+    const config = loadAppConfig({
+      FETCHLINKS_DB: "/var/lib/fetchlinks/fetchlinks.db",
+    });
+
+    expect(config).toEqual({
+      fetchlinksDbPath: "/var/lib/fetchlinks/fetchlinks.db",
+      fetchlinksDbReadOnlyUri: "file:///var/lib/fetchlinks/fetchlinks.db?mode=ro",
+    });
+  });
+});
+
+
+describe("toReadOnlySqliteUri", () => {
+  it("encodes paths for SQLite URI use", () => {
+    expect(toReadOnlySqliteUri("/tmp/fetch links #1.db")).toBe(
+      "file:///tmp/fetch%20links%20%231.db?mode=ro",
+    );
+  });
+});

--- a/web/src/server/config.ts
+++ b/web/src/server/config.ts
@@ -1,0 +1,55 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+type Env = Partial<Record<string, string | undefined>>;
+
+export type AppConfig = {
+  fetchlinksDbPath: string;
+  fetchlinksDbReadOnlyUri: string;
+};
+
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
+
+export function loadAppConfig(env: Env = process.env): AppConfig {
+  const fetchlinksDbPath = readRequiredAbsolutePath(env, "FETCHLINKS_DB");
+
+  return {
+    fetchlinksDbPath,
+    fetchlinksDbReadOnlyUri: toReadOnlySqliteUri(fetchlinksDbPath),
+  };
+}
+
+export function toReadOnlySqliteUri(dbPath: string): string {
+  const trimmedPath = dbPath.trim();
+
+  if (trimmedPath.length === 0) {
+    throw new ConfigError("FETCHLINKS_DB must not be empty.");
+  }
+
+  const fileUrl = pathToFileURL(trimmedPath);
+  fileUrl.searchParams.set("mode", "ro");
+
+  return fileUrl.href;
+}
+
+function readRequiredAbsolutePath(env: Env, name: string): string {
+  const value = env[name]?.trim();
+
+  if (!value) {
+    throw new ConfigError(
+      `${name} is required. Set it to the absolute path of the fetchlinks SQLite database.`,
+    );
+  }
+
+  if (!path.isAbsolute(value)) {
+    throw new ConfigError(`${name} must be an absolute path.`);
+  }
+
+  return value;
+}

--- a/web/tsconfig.typecheck.json
+++ b/web/tsconfig.typecheck.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "next-env.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.mts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".next"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a tracked web/.env.example with FETCHLINKS_DB guidance
- add server-side environment loading for FETCHLINKS_DB with clear ConfigError messages
- generate a read-only SQLite file URI for later DB access
- add unit tests for missing, empty, relative, absolute, and encoded DB paths
- make typecheck use a source-only tsconfig so stale Next dev artifacts do not break standalone tsc

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npm audit --audit-level=moderate
- FETCHLINKS_DB=/tmp/fetchlinks.db npm run dev -- --hostname 127.0.0.1 --port 3000 and browser check