### PR TITLE
Ignore webapp plan in web scaffold

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# plan
+webapp_plan.md
+
 # dependencies
 /node_modules
 /.pnp


### PR DESCRIPTION
## Summary
- add a local planning-note ignore entry to web/.gitignore

## Validation
- documentation/ignore-only change; no runtime checks needed