### PR TITLE
Add read-only SQLite DB layer

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -10,6 +10,8 @@ The scaffold targets Node 24.15 or newer with npm 11.12 or newer.
 
 Copy `.env.example` to `.env.local` for local development and set `FETCHLINKS_DB` to the absolute path of the SQLite database written by the fetchlinks ingestion app. The web app treats this database as read-only.
 
+SQLite access uses Node's built-in `node:sqlite` module, so no external SQLite npm package or native build step is required.
+
 ## Commands
 
 ```bash

--- a/web/src/server/db.test.ts
+++ b/web/src/server/db.test.ts
@@ -1,0 +1,169 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+
+import {
+  getPostCount,
+  openConfiguredFetchlinksDatabase,
+  openFetchlinksDatabase,
+  withFetchlinksDatabase,
+  type FetchlinksDatabase,
+} from "./db";
+
+type Fixture = {
+  dbPath: string;
+  cleanup: () => void;
+};
+
+describe("openFetchlinksDatabase", () => {
+  it("opens the configured SQLite database in read-only mode", () => {
+    const fixture = createFixtureDatabase();
+    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
+
+    try {
+      expect(database.isOpen).toBe(true);
+      expect(getPostCount(database)).toBe(2);
+      expect(() => insertPost(database)).toThrow();
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+
+  it("fails when a read-only database path does not exist", () => {
+    const fixture = createTempPath();
+
+    try {
+      expect(() =>
+        openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath }),
+      ).toThrow();
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+describe("openConfiguredFetchlinksDatabase", () => {
+  it("loads configuration from the provided environment", () => {
+    const fixture = createFixtureDatabase();
+    const database = openConfiguredFetchlinksDatabase({
+      FETCHLINKS_DB: fixture.dbPath,
+    });
+
+    try {
+      expect(getPostCount(database)).toBe(2);
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+});
+
+describe("withFetchlinksDatabase", () => {
+  it("closes the database after running the callback", () => {
+    const fixture = createFixtureDatabase();
+    let callbackDatabase: FetchlinksDatabase | undefined;
+
+    try {
+      const count = withFetchlinksDatabase(
+        { fetchlinksDbPath: fixture.dbPath },
+        (database) => {
+          callbackDatabase = database;
+          return getPostCount(database);
+        },
+      );
+
+      expect(count).toBe(2);
+      expect(callbackDatabase?.isOpen).toBe(false);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+function createFixtureDatabase(): Fixture {
+  const fixture = createTempPath();
+  const database = new DatabaseSync(fixture.dbPath);
+
+  database.exec(`
+    CREATE TABLE posts (
+      idx INTEGER PRIMARY KEY,
+      source TEXT NOT NULL,
+      author TEXT,
+      description TEXT,
+      direct_link TEXT,
+      date_created TEXT NOT NULL,
+      unique_id_string TEXT NOT NULL
+    );
+
+    CREATE TABLE post_urls (
+      idx INTEGER PRIMARY KEY,
+      post_id INTEGER NOT NULL,
+      position INTEGER NOT NULL,
+      url TEXT NOT NULL,
+      url_hash TEXT NOT NULL,
+      unshortened_url TEXT,
+      FOREIGN KEY (post_id) REFERENCES posts(idx)
+    );
+
+    INSERT INTO posts (
+      idx,
+      source,
+      author,
+      description,
+      direct_link,
+      date_created,
+      unique_id_string
+    ) VALUES
+      (1, 'rss', 'Ada', 'First post', 'https://example.com/first', '2026-04-27T10:00:00Z', 'rss-1'),
+      (2, 'reddit', 'Grace', 'Second post', 'https://example.com/second', '2026-04-28T10:00:00Z', 'reddit-2');
+
+    INSERT INTO post_urls (
+      idx,
+      post_id,
+      position,
+      url,
+      url_hash,
+      unshortened_url
+    ) VALUES
+      (1, 1, 0, 'https://short.example/a', 'hash-a', 'https://example.com/a'),
+      (2, 2, 0, 'https://example.com/b', 'hash-b', NULL);
+  `);
+
+  database.close();
+
+  return fixture;
+}
+
+function createTempPath(): Fixture {
+  const directory = mkdtempSync(path.join(tmpdir(), "fetchlinks-web-"));
+
+  return {
+    dbPath: path.join(directory, "fetchlinks.db"),
+    cleanup: () => rmSync(directory, { force: true, recursive: true }),
+  };
+}
+
+function insertPost(database: FetchlinksDatabase): void {
+  database.exec(`
+    INSERT INTO posts (
+      idx,
+      source,
+      author,
+      description,
+      direct_link,
+      date_created,
+      unique_id_string
+    ) VALUES (
+      3,
+      'rss',
+      'Read Only',
+      'This should fail',
+      'https://example.com/readonly',
+      '2026-04-29T10:00:00Z',
+      'rss-3'
+    );
+  `);
+}

--- a/web/src/server/db.ts
+++ b/web/src/server/db.ts
@@ -1,0 +1,49 @@
+import { DatabaseSync } from "node:sqlite";
+
+import { loadAppConfig, type AppConfig } from "./config";
+
+type DbConfig = Pick<AppConfig, "fetchlinksDbPath">;
+
+type Env = Partial<Record<string, string | undefined>>;
+
+type CountRow = {
+  count: number;
+};
+
+export type FetchlinksDatabase = DatabaseSync;
+
+export function openFetchlinksDatabase(config: DbConfig): FetchlinksDatabase {
+  return new DatabaseSync(config.fetchlinksDbPath, {
+    readOnly: true,
+    timeout: 5000,
+  });
+}
+
+export function openConfiguredFetchlinksDatabase(
+  env: Env = process.env,
+): FetchlinksDatabase {
+  return openFetchlinksDatabase(loadAppConfig(env));
+}
+
+export function withFetchlinksDatabase<T>(
+  config: DbConfig,
+  callback: (database: FetchlinksDatabase) => T,
+): T {
+  const database = openFetchlinksDatabase(config);
+
+  try {
+    return callback(database);
+  } finally {
+    if (database.isOpen) {
+      database.close();
+    }
+  }
+}
+
+export function getPostCount(database: FetchlinksDatabase): number {
+  const row = database.prepare("SELECT COUNT(*) AS count FROM posts").get() as
+    | CountRow
+    | undefined;
+
+  return row?.count ?? 0;
+}


### PR DESCRIPTION
## Summary
- add a server-side SQLite DB wrapper using Node's built-in node:sqlite module
- open the configured fetchlinks database in read-only mode
- add a first getPostCount query and connection helper that closes after use
- add temporary SQLite fixture tests for read-only behavior, missing DB paths, env loading, and connection cleanup
- document that no external SQLite npm package or native build step is required

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npm audit --audit-level=moderate
- read-only count against local real DB: posts=6584