### PR TITLE
Implement getPosts query

### DIFF
--- a/web/src/server/db.test.ts
+++ b/web/src/server/db.test.ts
@@ -5,6 +5,7 @@ import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 
 import {
+  getPosts,
   getPostCount,
   openConfiguredFetchlinksDatabase,
   openFetchlinksDatabase,
@@ -83,11 +84,112 @@ describe("withFetchlinksDatabase", () => {
   });
 });
 
-function createFixtureDatabase(): Fixture {
-  const fixture = createTempPath();
-  const database = new DatabaseSync(fixture.dbPath);
+describe("getPosts", () => {
+  it("returns posts newest first with pagination metadata", () => {
+    const fixture = createPostsQueryFixture();
+    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
 
-  database.exec(`
+    try {
+      const page = getPosts(database, { page: 1, pageSize: 2 });
+
+      expect(page).toMatchObject({
+        page: 1,
+        pageSize: 2,
+        totalPosts: 4,
+        totalPages: 2,
+        hasPreviousPage: false,
+        hasNextPage: true,
+      });
+      expect(page.posts.map((post) => post.uniqueId)).toEqual([
+        "reddit-2",
+        "rss-4",
+      ]);
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+
+  it("returns later pages using the requested page size", () => {
+    const fixture = createPostsQueryFixture();
+    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
+
+    try {
+      const page = getPosts(database, { page: 2, pageSize: 2 });
+
+      expect(page).toMatchObject({
+        page: 2,
+        pageSize: 2,
+        totalPosts: 4,
+        totalPages: 2,
+        hasPreviousPage: true,
+        hasNextPage: false,
+      });
+      expect(page.posts.map((post) => post.uniqueId)).toEqual([
+        "mastodon-3",
+        "rss-1",
+      ]);
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+
+  it("groups normalized URLs by post and prefers unshortened hrefs", () => {
+    const fixture = createPostsQueryFixture();
+    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
+
+    try {
+      const page = getPosts(database, { page: 1, pageSize: 1 });
+      const [post] = page.posts;
+
+      expect(post?.uniqueId).toBe("reddit-2");
+      expect(post?.urls).toEqual([
+        {
+          id: 3,
+          postId: 2,
+          position: 0,
+          originalUrl: "https://example.com/direct-b",
+          urlHash: "hash-b0",
+          unshortenedUrl: null,
+          href: "https://example.com/direct-b",
+        },
+        {
+          id: 2,
+          postId: 2,
+          position: 1,
+          originalUrl: "https://short.example/b",
+          urlHash: "hash-b1",
+          unshortenedUrl: "https://example.com/unshortened-b",
+          href: "https://example.com/unshortened-b",
+        },
+      ]);
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+
+  it("rejects invalid pagination options", () => {
+    const fixture = createPostsQueryFixture();
+    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
+
+    try {
+      expect(() => getPosts(database, { page: 0 })).toThrowError(
+        /page must be a positive integer/,
+      );
+      expect(() => getPosts(database, { pageSize: 1.5 })).toThrowError(
+        /pageSize must be a positive integer/,
+      );
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+});
+
+function createFixtureDatabase(): Fixture {
+  return createDatabaseWithSql(`
     CREATE TABLE posts (
       idx INTEGER PRIMARY KEY,
       source TEXT NOT NULL,
@@ -131,6 +233,64 @@ function createFixtureDatabase(): Fixture {
       (1, 1, 0, 'https://short.example/a', 'hash-a', 'https://example.com/a'),
       (2, 2, 0, 'https://example.com/b', 'hash-b', NULL);
   `);
+}
+
+function createPostsQueryFixture(): Fixture {
+  return createDatabaseWithSql(`
+    CREATE TABLE posts (
+      idx INTEGER PRIMARY KEY,
+      source TEXT NOT NULL,
+      author TEXT,
+      description TEXT,
+      direct_link TEXT,
+      date_created TEXT NOT NULL,
+      unique_id_string TEXT NOT NULL
+    );
+
+    CREATE TABLE post_urls (
+      idx INTEGER PRIMARY KEY,
+      post_id INTEGER NOT NULL,
+      position INTEGER NOT NULL,
+      url TEXT NOT NULL,
+      url_hash TEXT NOT NULL,
+      unshortened_url TEXT,
+      FOREIGN KEY (post_id) REFERENCES posts(idx)
+    );
+
+    INSERT INTO posts (
+      idx,
+      source,
+      author,
+      description,
+      direct_link,
+      date_created,
+      unique_id_string
+    ) VALUES
+      (1, 'rss', 'Ada', 'Oldest post', 'https://example.com/first', '2026-04-25T10:00:00Z', 'rss-1'),
+      (2, 'reddit', 'Grace', 'Newest post', 'https://example.com/second', '2026-04-28T10:00:00Z', 'reddit-2'),
+      (3, 'mastodon', NULL, NULL, NULL, '2026-04-26T10:00:00Z', 'mastodon-3'),
+      (4, 'rss', 'Linus', 'Tie-break post', 'https://example.com/fourth', '2026-04-26T10:00:00Z', 'rss-4');
+
+    INSERT INTO post_urls (
+      idx,
+      post_id,
+      position,
+      url,
+      url_hash,
+      unshortened_url
+    ) VALUES
+      (1, 1, 0, 'https://short.example/a', 'hash-a', 'https://example.com/a'),
+      (2, 2, 1, 'https://short.example/b', 'hash-b1', 'https://example.com/unshortened-b'),
+      (3, 2, 0, 'https://example.com/direct-b', 'hash-b0', NULL),
+      (4, 4, 0, 'https://example.com/d', 'hash-d', NULL);
+  `);
+}
+
+function createDatabaseWithSql(sql: string): Fixture {
+  const fixture = createTempPath();
+  const database = new DatabaseSync(fixture.dbPath);
+
+  database.exec(sql);
 
   database.close();
 

--- a/web/src/server/db.ts
+++ b/web/src/server/db.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
 
+import type { PostPage, PostUrl } from "../models/read-models";
 import { loadAppConfig, type AppConfig } from "./config";
 
 type DbConfig = Pick<AppConfig, "fetchlinksDbPath">;
@@ -9,6 +10,33 @@ type Env = Partial<Record<string, string | undefined>>;
 type CountRow = {
   count: number;
 };
+
+type PostRow = {
+  id: number;
+  source: string;
+  author: string | null;
+  description: string | null;
+  directLink: string | null;
+  dateCreated: string;
+  uniqueId: string;
+};
+
+type PostUrlRow = {
+  id: number;
+  postId: number;
+  position: number;
+  originalUrl: string;
+  urlHash: string;
+  unshortenedUrl: string | null;
+};
+
+export type GetPostsOptions = {
+  page?: number;
+  pageSize?: number;
+};
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 50;
 
 export type FetchlinksDatabase = DatabaseSync;
 
@@ -46,4 +74,104 @@ export function getPostCount(database: FetchlinksDatabase): number {
     | undefined;
 
   return row?.count ?? 0;
+}
+
+export function getPosts(
+  database: FetchlinksDatabase,
+  options: GetPostsOptions = {},
+): PostPage {
+  const page = normalizePositiveInteger(options.page, DEFAULT_PAGE, "page");
+  const pageSize = normalizePositiveInteger(
+    options.pageSize,
+    DEFAULT_PAGE_SIZE,
+    "pageSize",
+  );
+  const totalPosts = getPostCount(database);
+  const totalPages = Math.ceil(totalPosts / pageSize);
+  const postRows = database
+    .prepare(`
+      SELECT
+        idx AS id,
+        source,
+        author,
+        description,
+        direct_link AS directLink,
+        date_created AS dateCreated,
+        unique_id_string AS uniqueId
+      FROM posts
+      ORDER BY date_created DESC, idx DESC
+      LIMIT ? OFFSET ?
+    `)
+    .all(pageSize, (page - 1) * pageSize) as PostRow[];
+  const urlsByPostId = getUrlsByPostId(
+    database,
+    postRows.map((post) => post.id),
+  );
+
+  return {
+    posts: postRows.map((post) => ({
+      ...post,
+      urls: urlsByPostId.get(post.id) ?? [],
+    })),
+    page,
+    pageSize,
+    totalPosts,
+    totalPages,
+    hasPreviousPage: page > 1,
+    hasNextPage: page < totalPages,
+  };
+}
+
+function getUrlsByPostId(
+  database: FetchlinksDatabase,
+  postIds: number[],
+): Map<number, PostUrl[]> {
+  if (postIds.length === 0) {
+    return new Map();
+  }
+
+  const placeholders = postIds.map(() => "?").join(", ");
+  const urlRows = database
+    .prepare(`
+      SELECT
+        idx AS id,
+        post_id AS postId,
+        position,
+        url AS originalUrl,
+        url_hash AS urlHash,
+        unshortened_url AS unshortenedUrl
+      FROM post_urls
+      WHERE post_id IN (${placeholders})
+      ORDER BY post_id ASC, position ASC, idx ASC
+    `)
+    .all(...postIds) as PostUrlRow[];
+  const urlsByPostId = new Map<number, PostUrl[]>();
+
+  for (const url of urlRows) {
+    const postUrls = urlsByPostId.get(url.postId) ?? [];
+
+    postUrls.push({
+      ...url,
+      href: url.unshortenedUrl ?? url.originalUrl,
+    });
+    urlsByPostId.set(url.postId, postUrls);
+  }
+
+  return urlsByPostId;
+}
+
+function normalizePositiveInteger(
+  value: number | undefined,
+  fallback: number,
+  name: string,
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (!Number.isInteger(value) || value < 1) {
+    throw new RangeError(`${name} must be a positive integer.`);
+  }
+
+  return value;
 }


### PR DESCRIPTION
## Summary
- add getPosts query support for newest-first post pages
- include pagination metadata and page/pageSize validation
- collect normalized post_urls per post ordered by position
- prefer unshortened_url for href while preserving the original URL
- expand SQLite fixture tests for ordering, pagination, multi-URL posts, unshortened URLs, and invalid pagination

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npm audit --audit-level=moderate