### PR TITLE
Build latest posts page states

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2,9 +2,12 @@
   --background: #f5f7fb;
   --foreground: #181816;
   --muted: #52606d;
+  --subtle: #eef2f7;
   --panel: #ffffff;
   --border: #d8dee9;
   --accent: #167a5b;
+  --accent-strong: #0f5a43;
+  --danger: #a23b3b;
 }
 
 html {
@@ -40,37 +43,187 @@ a {
 }
 
 .shell {
-  width: min(960px, 100%);
+  width: min(1040px, 100%);
   margin: 0 auto;
-  padding: 48px 24px;
+  padding: 32px 24px;
 }
 
-.intro {
+.page-header {
   width: 100%;
-  max-width: 680px;
-  padding: 32px;
-  border: 1px solid var(--border);
-  border-top: 4px solid var(--accent);
-  border-radius: 8px;
-  background: var(--panel);
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
 }
 
 .eyebrow {
-  margin-bottom: 12px;
   color: var(--accent);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 700;
   text-transform: uppercase;
 }
 
 h1 {
-  margin-bottom: 16px;
+  margin-top: 6px;
   font-size: 32px;
   line-height: 1.2;
+}
+
+h2 {
+  font-size: 20px;
+  line-height: 1.3;
 }
 
 p {
   color: var(--muted);
   font-size: 16px;
   line-height: 1.6;
+}
+
+.page-summary {
+  margin-top: 6px;
+}
+
+.post-list {
+  display: grid;
+  gap: 16px;
+}
+
+.post-item,
+.state {
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.post-item {
+  display: grid;
+  gap: 12px;
+}
+
+.post-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.post-meta span:not(:last-child)::after {
+  margin-left: 12px;
+  color: var(--border);
+  content: "/";
+}
+
+.post-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.post-actions a,
+.pagination a {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  color: var(--accent-strong);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.post-actions a {
+  padding: 0 12px;
+}
+
+.post-actions a:hover,
+.pagination a:hover {
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.url-list {
+  display: grid;
+  gap: 8px;
+  padding-left: 20px;
+  overflow-wrap: anywhere;
+}
+
+.url-list a {
+  color: var(--accent-strong);
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.url-original {
+  display: block;
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.state {
+  display: grid;
+  gap: 8px;
+}
+
+.state-error {
+  border-color: color-mix(in srgb, var(--danger) 35%, var(--border));
+}
+
+.state-error h2 {
+  color: var(--danger);
+}
+
+.pagination {
+  display: grid;
+  grid-template-columns: 112px 1fr 112px;
+  gap: 12px;
+  align-items: center;
+  margin-top: 24px;
+  color: var(--muted);
+  font-size: 14px;
+  text-align: center;
+}
+
+.pagination a,
+.pagination span[aria-disabled="true"] {
+  padding: 0 12px;
+}
+
+.pagination span[aria-disabled="true"] {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--subtle);
+  color: var(--muted);
+}
+
+@media (max-width: 640px) {
+  .shell {
+    padding: 24px 16px;
+  }
+
+  .page-header {
+    display: block;
+  }
+
+  h1 {
+    font-size: 28px;
+  }
+
+  .pagination {
+    grid-template-columns: 1fr;
+  }
 }

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -1,14 +1,91 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import Home from "./page";
+import type { PostPage } from "../models/read-models";
+import { LatestPostsView, loadLatestPosts } from "./page";
 
 describe("Home", () => {
-  it("renders the Fetchlinks scaffold message", () => {
-    const markup = renderToStaticMarkup(Home());
+  it("renders posts with metadata, extracted URLs, and pagination links", () => {
+    const markup = renderToStaticMarkup(
+      <LatestPostsView result={{ status: "ready", page: createPostPage() }} />,
+    );
 
-    expect(markup).toContain("Fetchlinks Web");
-    expect(markup).toContain("Next.js scaffold is ready.");
-    expect(markup).toContain("active Fetchlinks web UI");
+    expect(markup).toContain("Latest posts");
+    expect(markup).toContain("Newest post");
+    expect(markup).toContain("reddit");
+    expect(markup).toContain("Grace");
+    expect(markup).toContain("Apr 28, 2026, 10:00 AM");
+    expect(markup).toContain("Source post");
+    expect(markup).toContain("example.com/unshortened-b");
+    expect(markup).toContain("via short.example/b");
+    expect(markup).toContain('href="/?page=2"');
+  });
+
+  it("renders an empty state when no posts exist", () => {
+    const markup = renderToStaticMarkup(
+      <LatestPostsView
+        result={{
+          status: "ready",
+          page: createPostPage({ posts: [], totalPosts: 0, totalPages: 0 }),
+        }}
+      />,
+    );
+
+    expect(markup).toContain("No posts");
+    expect(markup).toContain("No posts have been collected yet.");
+    expect(markup).toContain("Page 1 of 1");
+  });
+
+  it("renders a safe error state when the database cannot be configured", () => {
+    const result = loadLatestPosts({ env: {} });
+    const markup = renderToStaticMarkup(<LatestPostsView result={result} />);
+
+    expect(result.status).toBe("error");
+    expect(markup).toContain("Posts are unavailable");
+    expect(markup).toContain("The database could not be opened.");
+    expect(markup).not.toContain("FETCHLINKS_DB is required");
   });
 });
+
+function createPostPage(overrides: Partial<PostPage> = {}): PostPage {
+  return {
+    posts: [
+      {
+        id: 2,
+        source: "reddit",
+        author: "Grace",
+        description: "Newest post",
+        directLink: "https://example.com/source-post",
+        dateCreated: "2026-04-28T10:00:00Z",
+        uniqueId: "reddit-2",
+        urls: [
+          {
+            id: 3,
+            postId: 2,
+            position: 0,
+            originalUrl: "https://example.com/direct-b",
+            urlHash: "hash-b0",
+            unshortenedUrl: null,
+            href: "https://example.com/direct-b",
+          },
+          {
+            id: 2,
+            postId: 2,
+            position: 1,
+            originalUrl: "https://short.example/b",
+            urlHash: "hash-b1",
+            unshortenedUrl: "https://example.com/unshortened-b",
+            href: "https://example.com/unshortened-b",
+          },
+        ],
+      },
+    ],
+    page: 1,
+    pageSize: 50,
+    totalPosts: 51,
+    totalPages: 2,
+    hasPreviousPage: false,
+    hasNextPage: true,
+    ...overrides,
+  };
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,15 +1,219 @@
-export default function Home() {
+import type { PostPage, PostSummary, PostUrl } from "../models/read-models";
+import { getPosts, openConfiguredFetchlinksDatabase } from "../server/db";
+
+type PageSearchParams = Record<string, string | string[] | undefined>;
+
+type HomeProps = {
+  searchParams?: Promise<PageSearchParams>;
+};
+
+type Env = Partial<Record<string, string | undefined>>;
+
+type LatestPostsResult =
+  | {
+      status: "ready";
+      page: PostPage;
+    }
+  | {
+      status: "error";
+    };
+
+const POSTS_PER_PAGE = 50;
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeStyle: "short",
+  timeZone: "UTC",
+});
+
+export const dynamic = "force-dynamic";
+
+export default async function Home({ searchParams }: HomeProps = {}) {
+  const resolvedSearchParams = await searchParams;
+  const page = getPageFromSearchParams(resolvedSearchParams);
+
+  return <LatestPostsView result={loadLatestPosts({ page })} />;
+}
+
+export function loadLatestPosts({
+  env = process.env,
+  page = 1,
+}: {
+  env?: Env;
+  page?: number;
+} = {}): LatestPostsResult {
+  try {
+    const database = openConfiguredFetchlinksDatabase(env);
+
+    try {
+      return {
+        status: "ready",
+        page: getPosts(database, { page, pageSize: POSTS_PER_PAGE }),
+      };
+    } finally {
+      if (database.isOpen) {
+        database.close();
+      }
+    }
+  } catch {
+    return { status: "error" };
+  }
+}
+
+export function LatestPostsView({ result }: { result: LatestPostsResult }) {
+  if (result.status === "error") {
+    return (
+      <main className="shell">
+        <PageHeader />
+        <section className="state state-error" role="alert">
+          <h2>Posts are unavailable</h2>
+          <p>The database could not be opened. Check the server configuration.</p>
+        </section>
+      </main>
+    );
+  }
+
+  const { page } = result;
+
   return (
     <main className="shell">
-      <section className="intro">
-        <p className="eyebrow">Fetchlinks Web</p>
-        <h1>Next.js scaffold is ready.</h1>
-        <p>
-          This placeholder confirms the new TypeScript App Router application is
-          running as the active Fetchlinks web UI. Database-backed link browsing
-          will be added in later steps.
-        </p>
-      </section>
+      <PageHeader page={page} />
+      {page.posts.length === 0 ? <EmptyPostsState page={page} /> : null}
+      {page.posts.length > 0 ? (
+        <section className="post-list" aria-label="Latest posts">
+          {page.posts.map((post) => (
+            <PostListItem key={post.id} post={post} />
+          ))}
+        </section>
+      ) : null}
+      <Pagination page={page} />
     </main>
   );
+}
+
+function PageHeader({ page }: { page?: PostPage }) {
+  return (
+    <header className="page-header">
+      <p className="eyebrow">Fetchlinks</p>
+      <div>
+        <h1>Latest posts</h1>
+        {page ? (
+          <p className="page-summary">
+            {page.totalPosts.toLocaleString("en-US")} posts collected
+          </p>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+
+function EmptyPostsState({ page }: { page: PostPage }) {
+  const message =
+    page.totalPosts === 0
+      ? "No posts have been collected yet."
+      : "No posts were found on this page.";
+
+  return (
+    <section className="state">
+      <h2>No posts</h2>
+      <p>{message}</p>
+    </section>
+  );
+}
+
+function PostListItem({ post }: { post: PostSummary }) {
+  return (
+    <article className="post-item">
+      <div className="post-meta">
+        <span>{post.source}</span>
+        {post.author ? <span>{post.author}</span> : null}
+        <time dateTime={post.dateCreated}>{formatPostDate(post.dateCreated)}</time>
+      </div>
+      <h2>{post.description ?? "Untitled post"}</h2>
+      <div className="post-actions">
+        {post.directLink ? (
+          <a href={post.directLink} rel="noreferrer" target="_blank">
+            Source post
+          </a>
+        ) : null}
+      </div>
+      {post.urls.length > 0 ? (
+        <ul className="url-list">
+          {post.urls.map((url) => (
+            <PostUrlItem key={url.id} url={url} />
+          ))}
+        </ul>
+      ) : null}
+    </article>
+  );
+}
+
+function PostUrlItem({ url }: { url: PostUrl }) {
+  const usesUnshortenedUrl = url.href !== url.originalUrl;
+
+  return (
+    <li>
+      <a href={url.href} rel="noreferrer" target="_blank">
+        {formatUrlLabel(url.href)}
+      </a>
+      {usesUnshortenedUrl ? (
+        <span className="url-original">via {formatUrlLabel(url.originalUrl)}</span>
+      ) : null}
+    </li>
+  );
+}
+
+function Pagination({ page }: { page: PostPage }) {
+  const totalPages = Math.max(page.totalPages, 1);
+
+  return (
+    <nav className="pagination" aria-label="Posts pagination">
+      {page.hasPreviousPage ? (
+        <a href={buildPageHref(page.page - 1)}>Previous</a>
+      ) : (
+        <span aria-disabled="true">Previous</span>
+      )}
+      <span>
+        Page {page.page.toLocaleString("en-US")} of {totalPages.toLocaleString("en-US")}
+      </span>
+      {page.hasNextPage ? (
+        <a href={buildPageHref(page.page + 1)}>Next</a>
+      ) : (
+        <span aria-disabled="true">Next</span>
+      )}
+    </nav>
+  );
+}
+
+function getPageFromSearchParams(searchParams: PageSearchParams | undefined) {
+  const value = searchParams?.page;
+  const page = Array.isArray(value) ? value[0] : value;
+
+  if (!page) {
+    return 1;
+  }
+
+  const parsedPage = Number(page);
+
+  return Number.isInteger(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+}
+
+function buildPageHref(page: number) {
+  return page === 1 ? "/" : `/?page=${page}`;
+}
+
+function formatPostDate(value: string) {
+  const date = new Date(value);
+
+  return Number.isNaN(date.valueOf()) ? value : dateFormatter.format(date);
+}
+
+function formatUrlLabel(value: string) {
+  try {
+    const url = new URL(value);
+
+    return `${url.hostname}${url.pathname}${url.search}`;
+  } catch {
+    return value;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the scaffold homepage with a DB-backed latest posts page
- render post description, source, author, date, source post link, and extracted URLs
- add previous/next pagination for the root route
- add empty and safe database-error states
- update page rendering tests for posts, pagination, empty state, and missing DB handling
- expand global styles for the link browsing layout

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npm audit --audit-level=moderate
- browser checked real DB at http://127.0.0.1:3100 showing 6,584 posts
- browser checked empty DB state
- browser checked missing DB safe error state