### PR TITLE
Add source domain and search filters

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -87,6 +87,75 @@ p {
   margin-top: 6px;
 }
 
+.filter-bar {
+  display: grid;
+  grid-template-columns: minmax(220px, 2fr) minmax(160px, 1fr) minmax(160px, 1fr) auto auto;
+  gap: 12px;
+  align-items: end;
+  margin-bottom: 24px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+}
+
+.filter-bar label {
+  display: grid;
+  min-width: 0;
+  gap: 6px;
+}
+
+.filter-bar label span {
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.filter-bar input,
+.filter-bar select {
+  width: 100%;
+  min-height: 38px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #ffffff;
+  color: var(--foreground);
+  font: inherit;
+}
+
+.filter-bar input {
+  padding: 0 10px;
+}
+
+.filter-bar select {
+  padding: 0 8px;
+}
+
+.filter-bar button,
+.clear-filters {
+  display: inline-flex;
+  min-height: 38px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 14px;
+  border-radius: 6px;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.filter-bar button {
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.clear-filters {
+  border: 1px solid var(--border);
+  background: var(--subtle);
+  color: var(--muted);
+}
+
 .post-list {
   display: grid;
   gap: 16px;
@@ -221,6 +290,10 @@ p {
 
   h1 {
     font-size: 28px;
+  }
+
+  .filter-bar {
+    grid-template-columns: 1fr;
   }
 
   .pagination {

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -1,14 +1,12 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import type { PostPage } from "../models/read-models";
+import type { DomainSummary, PostPage, SourceSummary } from "../models/read-models";
 import { LatestPostsView, loadLatestPosts } from "./page";
 
 describe("Home", () => {
   it("renders posts with metadata, extracted URLs, and pagination links", () => {
-    const markup = renderToStaticMarkup(
-      <LatestPostsView result={{ status: "ready", page: createPostPage() }} />,
-    );
+    const markup = renderToStaticMarkup(<LatestPostsView result={createReadyResult()} />);
 
     expect(markup).toContain("Latest posts");
     expect(markup).toContain("Newest post");
@@ -21,19 +19,53 @@ describe("Home", () => {
     expect(markup).toContain('href="/?page=2"');
   });
 
+  it("renders filters and preserves them in pagination links", () => {
+    const markup = renderToStaticMarkup(
+      <LatestPostsView
+        result={createReadyResult({
+          filters: { source: "reddit", domain: "example.com", q: "AI" },
+          page: createPostPage({ totalPosts: 75 }),
+        })}
+      />,
+    );
+
+    expect(markup).toContain("75 matching posts");
+    expect(markup).toContain('name="q"');
+    expect(markup).toContain('value="AI"');
+    expect(markup).toContain("reddit (1)");
+    expect(markup).toContain("example.com (1)");
+    expect(markup).toContain('href="/"');
+    expect(markup).toContain(
+      'href="/?source=reddit&amp;domain=example.com&amp;q=AI&amp;page=2"',
+    );
+  });
+
   it("renders an empty state when no posts exist", () => {
     const markup = renderToStaticMarkup(
       <LatestPostsView
-        result={{
-          status: "ready",
+        result={createReadyResult({
           page: createPostPage({ posts: [], totalPosts: 0, totalPages: 0 }),
-        }}
+        })}
       />,
     );
 
     expect(markup).toContain("No posts");
     expect(markup).toContain("No posts have been collected yet.");
     expect(markup).toContain("Page 1 of 1");
+  });
+
+  it("renders a filtered empty state when filters have no matches", () => {
+    const markup = renderToStaticMarkup(
+      <LatestPostsView
+        result={createReadyResult({
+          filters: { q: "missing" },
+          page: createPostPage({ posts: [], totalPosts: 0, totalPages: 0 }),
+        })}
+      />,
+    );
+
+    expect(markup).toContain("0 matching posts");
+    expect(markup).toContain("No posts match the current filters.");
   });
 
   it("renders a safe error state when the database cannot be configured", () => {
@@ -46,6 +78,26 @@ describe("Home", () => {
     expect(markup).not.toContain("FETCHLINKS_DB is required");
   });
 });
+
+function createReadyResult({
+  domains = createDomainSummaries(),
+  filters = {},
+  page = createPostPage(),
+  sources = createSourceSummaries(),
+}: {
+  domains?: DomainSummary[];
+  filters?: { source?: string; domain?: string; q?: string };
+  page?: PostPage;
+  sources?: SourceSummary[];
+} = {}) {
+  return {
+    status: "ready" as const,
+    page,
+    sources,
+    domains,
+    filters,
+  };
+}
 
 function createPostPage(overrides: Partial<PostPage> = {}): PostPage {
   return {
@@ -88,4 +140,36 @@ function createPostPage(overrides: Partial<PostPage> = {}): PostPage {
     hasNextPage: true,
     ...overrides,
   };
+}
+
+function createSourceSummaries(): SourceSummary[] {
+  return [
+    {
+      source: "reddit",
+      postCount: 1,
+      latestPostDate: "2026-04-28T10:00:00Z",
+    },
+    {
+      source: "rss",
+      postCount: 50,
+      latestPostDate: "2026-04-27T10:00:00Z",
+    },
+  ];
+}
+
+function createDomainSummaries(): DomainSummary[] {
+  return [
+    {
+      domain: "example.com",
+      postCount: 1,
+      urlCount: 2,
+      latestPostDate: "2026-04-28T10:00:00Z",
+    },
+    {
+      domain: "docs.example.org",
+      postCount: 12,
+      urlCount: 12,
+      latestPostDate: "2026-04-27T10:00:00Z",
+    },
+  ];
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,5 +1,19 @@
-import type { PostPage, PostSummary, PostUrl } from "../models/read-models";
-import { getPosts, openConfiguredFetchlinksDatabase } from "../server/db";
+import Link from "next/link";
+
+import type {
+  DomainSummary,
+  PostPage,
+  PostSummary,
+  PostUrl,
+  SourceSummary,
+} from "../models/read-models";
+import {
+  getDomainSummaries,
+  getPosts,
+  getSourceSummaries,
+  openConfiguredFetchlinksDatabase,
+  type PostFilters,
+} from "../server/db";
 
 type PageSearchParams = Record<string, string | string[] | undefined>;
 
@@ -9,10 +23,19 @@ type HomeProps = {
 
 type Env = Partial<Record<string, string | undefined>>;
 
+type ActiveFilters = {
+  source?: string;
+  domain?: string;
+  q?: string;
+};
+
 type LatestPostsResult =
   | {
       status: "ready";
       page: PostPage;
+      sources: SourceSummary[];
+      domains: DomainSummary[];
+      filters: ActiveFilters;
     }
   | {
       status: "error";
@@ -31,24 +54,42 @@ export const dynamic = "force-dynamic";
 export default async function Home({ searchParams }: HomeProps = {}) {
   const resolvedSearchParams = await searchParams;
   const page = getPageFromSearchParams(resolvedSearchParams);
+  const filters = getFiltersFromSearchParams(resolvedSearchParams);
 
-  return <LatestPostsView result={loadLatestPosts({ page })} />;
+  return <LatestPostsView result={loadLatestPosts({ page, filters })} />;
 }
 
 export function loadLatestPosts({
   env = process.env,
+  filters = {},
   page = 1,
 }: {
   env?: Env;
+  filters?: PostFilters;
   page?: number;
 } = {}): LatestPostsResult {
+  const activeFilters = normalizeFilters(filters);
+
   try {
     const database = openConfiguredFetchlinksDatabase(env);
 
     try {
       return {
         status: "ready",
-        page: getPosts(database, { page, pageSize: POSTS_PER_PAGE }),
+        page: getPosts(database, {
+          ...activeFilters,
+          page,
+          pageSize: POSTS_PER_PAGE,
+        }),
+        sources: getSourceSummaries(database, {
+          domain: activeFilters.domain,
+          q: activeFilters.q,
+        }),
+        domains: getDomainSummaries(database, {
+          source: activeFilters.source,
+          q: activeFilters.q,
+        }),
+        filters: activeFilters,
       };
     } finally {
       if (database.isOpen) {
@@ -77,8 +118,15 @@ export function LatestPostsView({ result }: { result: LatestPostsResult }) {
 
   return (
     <main className="shell">
-      <PageHeader page={page} />
-      {page.posts.length === 0 ? <EmptyPostsState page={page} /> : null}
+      <PageHeader filters={result.filters} page={page} />
+      <FilterBar
+        domains={result.domains}
+        filters={result.filters}
+        sources={result.sources}
+      />
+      {page.posts.length === 0 ? (
+        <EmptyPostsState filters={result.filters} page={page} />
+      ) : null}
       {page.posts.length > 0 ? (
         <section className="post-list" aria-label="Latest posts">
           {page.posts.map((post) => (
@@ -86,12 +134,22 @@ export function LatestPostsView({ result }: { result: LatestPostsResult }) {
           ))}
         </section>
       ) : null}
-      <Pagination page={page} />
+      <Pagination filters={result.filters} page={page} />
     </main>
   );
 }
 
-function PageHeader({ page }: { page?: PostPage }) {
+function PageHeader({
+  filters = {},
+  page,
+}: {
+  filters?: ActiveFilters;
+  page?: PostPage;
+}) {
+  const summaryLabel = hasActiveFilters(filters)
+    ? "matching posts"
+    : "posts collected";
+
   return (
     <header className="page-header">
       <p className="eyebrow">Fetchlinks</p>
@@ -99,7 +157,7 @@ function PageHeader({ page }: { page?: PostPage }) {
         <h1>Latest posts</h1>
         {page ? (
           <p className="page-summary">
-            {page.totalPosts.toLocaleString("en-US")} posts collected
+            {page.totalPosts.toLocaleString("en-US")} {summaryLabel}
           </p>
         ) : null}
       </div>
@@ -107,9 +165,66 @@ function PageHeader({ page }: { page?: PostPage }) {
   );
 }
 
-function EmptyPostsState({ page }: { page: PostPage }) {
+function FilterBar({
+  domains,
+  filters,
+  sources,
+}: {
+  domains: DomainSummary[];
+  filters: ActiveFilters;
+  sources: SourceSummary[];
+}) {
+  const sourceOptions = includeActiveSource(sources, filters.source);
+  const domainOptions = includeActiveDomain(domains, filters.domain);
+
+  return (
+    <form action="/" className="filter-bar" method="get">
+      <label>
+        <span>Search</span>
+        <input
+          defaultValue={filters.q ?? ""}
+          name="q"
+          placeholder="Description, author, URL"
+          type="search"
+        />
+      </label>
+      <label>
+        <span>Source</span>
+        <select defaultValue={filters.source ?? ""} name="source">
+          <option value="">Any source</option>
+          {sourceOptions.map((source) => (
+            <option key={source.source} value={source.source}>
+              {source.source} ({source.postCount.toLocaleString("en-US")})
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        <span>Domain</span>
+        <select defaultValue={filters.domain ?? ""} name="domain">
+          <option value="">Any domain</option>
+          {domainOptions.map((domain) => (
+            <option key={domain.domain} value={domain.domain}>
+              {domain.domain} ({domain.postCount.toLocaleString("en-US")})
+            </option>
+          ))}
+        </select>
+      </label>
+      <button type="submit">Apply</button>
+      {hasActiveFilters(filters) ? (
+        <Link className="clear-filters" href="/">
+          Clear
+        </Link>
+      ) : null}
+    </form>
+  );
+}
+
+function EmptyPostsState({ filters, page }: { filters: ActiveFilters; page: PostPage }) {
   const message =
-    page.totalPosts === 0
+    page.totalPosts === 0 && hasActiveFilters(filters)
+      ? "No posts match the current filters."
+      : page.totalPosts === 0
       ? "No posts have been collected yet."
       : "No posts were found on this page.";
 
@@ -163,13 +278,13 @@ function PostUrlItem({ url }: { url: PostUrl }) {
   );
 }
 
-function Pagination({ page }: { page: PostPage }) {
+function Pagination({ filters, page }: { filters: ActiveFilters; page: PostPage }) {
   const totalPages = Math.max(page.totalPages, 1);
 
   return (
     <nav className="pagination" aria-label="Posts pagination">
       {page.hasPreviousPage ? (
-        <a href={buildPageHref(page.page - 1)}>Previous</a>
+        <Link href={buildPageHref(page.page - 1, filters)}>Previous</Link>
       ) : (
         <span aria-disabled="true">Previous</span>
       )}
@@ -177,7 +292,7 @@ function Pagination({ page }: { page: PostPage }) {
         Page {page.page.toLocaleString("en-US")} of {totalPages.toLocaleString("en-US")}
       </span>
       {page.hasNextPage ? (
-        <a href={buildPageHref(page.page + 1)}>Next</a>
+        <Link href={buildPageHref(page.page + 1, filters)}>Next</Link>
       ) : (
         <span aria-disabled="true">Next</span>
       )}
@@ -185,9 +300,18 @@ function Pagination({ page }: { page: PostPage }) {
   );
 }
 
+function getFiltersFromSearchParams(
+  searchParams: PageSearchParams | undefined,
+): ActiveFilters {
+  return normalizeFilters({
+    source: getSingleSearchParam(searchParams, "source"),
+    domain: getSingleSearchParam(searchParams, "domain"),
+    q: getSingleSearchParam(searchParams, "q"),
+  });
+}
+
 function getPageFromSearchParams(searchParams: PageSearchParams | undefined) {
-  const value = searchParams?.page;
-  const page = Array.isArray(value) ? value[0] : value;
+  const page = getSingleSearchParam(searchParams, "page");
 
   if (!page) {
     return 1;
@@ -198,8 +322,37 @@ function getPageFromSearchParams(searchParams: PageSearchParams | undefined) {
   return Number.isInteger(parsedPage) && parsedPage > 0 ? parsedPage : 1;
 }
 
-function buildPageHref(page: number) {
-  return page === 1 ? "/" : `/?page=${page}`;
+function getSingleSearchParam(
+  searchParams: PageSearchParams | undefined,
+  name: string,
+) {
+  const value = searchParams?.[name];
+
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function buildPageHref(page: number, filters: ActiveFilters) {
+  const params = new URLSearchParams();
+
+  if (filters.source) {
+    params.set("source", filters.source);
+  }
+
+  if (filters.domain) {
+    params.set("domain", filters.domain);
+  }
+
+  if (filters.q) {
+    params.set("q", filters.q);
+  }
+
+  if (page > 1) {
+    params.set("page", String(page));
+  }
+
+  const query = params.toString();
+
+  return query ? `/?${query}` : "/";
 }
 
 function formatPostDate(value: string) {
@@ -216,4 +369,47 @@ function formatUrlLabel(value: string) {
   } catch {
     return value;
   }
+}
+
+function normalizeFilters(filters: PostFilters): ActiveFilters {
+  const source = normalizeOptionalText(filters.source);
+  const domain = normalizeOptionalText(filters.domain)?.toLowerCase();
+  const q = normalizeOptionalText(filters.q);
+
+  return { source, domain, q };
+}
+
+function normalizeOptionalText(value: string | undefined): string | undefined {
+  const text = value?.trim();
+
+  return text ? text : undefined;
+}
+
+function hasActiveFilters(filters: ActiveFilters) {
+  return Boolean(filters.source || filters.domain || filters.q);
+}
+
+function includeActiveSource(
+  sources: SourceSummary[],
+  activeSource: string | undefined,
+): SourceSummary[] {
+  if (!activeSource || sources.some((source) => source.source === activeSource)) {
+    return sources;
+  }
+
+  return [{ source: activeSource, postCount: 0, latestPostDate: null }, ...sources];
+}
+
+function includeActiveDomain(
+  domains: DomainSummary[],
+  activeDomain: string | undefined,
+): DomainSummary[] {
+  if (!activeDomain || domains.some((domain) => domain.domain === activeDomain)) {
+    return domains;
+  }
+
+  return [
+    { domain: activeDomain, postCount: 0, urlCount: 0, latestPostDate: null },
+    ...domains,
+  ];
 }

--- a/web/src/server/db.test.ts
+++ b/web/src/server/db.test.ts
@@ -5,8 +5,10 @@ import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 
 import {
+  getDomainSummaries,
   getPosts,
   getPostCount,
+  getSourceSummaries,
   openConfiguredFetchlinksDatabase,
   openFetchlinksDatabase,
   withFetchlinksDatabase,
@@ -170,6 +172,75 @@ describe("getPosts", () => {
     }
   });
 
+  it("filters posts by source", () => {
+    const fixture = createPostsQueryFixture();
+    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
+
+    try {
+      const page = getPosts(database, { source: "rss", page: 1, pageSize: 10 });
+
+      expect(page).toMatchObject({ totalPosts: 2, totalPages: 1 });
+      expect(page.posts.map((post) => post.uniqueId)).toEqual(["rss-4", "rss-1"]);
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+
+  it("filters posts by extracted URL domain using normalized hrefs", () => {
+    const fixture = createPostsQueryFixture();
+    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
+
+    try {
+      const page = getPosts(database, {
+        domain: "EXAMPLE.com",
+        page: 1,
+        pageSize: 10,
+      });
+
+      expect(page).toMatchObject({ totalPosts: 2, totalPages: 1 });
+      expect(page.posts.map((post) => post.uniqueId)).toEqual(["reddit-2", "rss-1"]);
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+
+  it("searches post fields and extracted URLs", () => {
+    const fixture = createPostsQueryFixture();
+    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
+
+    try {
+      const urlMatch = getPosts(database, { q: "unshortened-B" });
+      const authorMatch = getPosts(database, { q: "linus" });
+
+      expect(urlMatch.posts.map((post) => post.uniqueId)).toEqual(["reddit-2"]);
+      expect(authorMatch.posts.map((post) => post.uniqueId)).toEqual(["rss-4"]);
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+
+  it("combines source, domain, and search filters", () => {
+    const fixture = createPostsQueryFixture();
+    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
+
+    try {
+      const page = getPosts(database, {
+        source: "rss",
+        domain: "docs.example.org",
+        q: "tie-break",
+      });
+
+      expect(page.posts.map((post) => post.uniqueId)).toEqual(["rss-4"]);
+      expect(page.totalPosts).toBe(1);
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+
   it("rejects invalid pagination options", () => {
     const fixture = createPostsQueryFixture();
     const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
@@ -181,6 +252,111 @@ describe("getPosts", () => {
       expect(() => getPosts(database, { pageSize: 1.5 })).toThrowError(
         /pageSize must be a positive integer/,
       );
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+});
+
+describe("getSourceSummaries", () => {
+  it("returns source counts ordered by popularity and name", () => {
+    const fixture = createPostsQueryFixture();
+    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
+
+    try {
+      expect(getSourceSummaries(database)).toEqual([
+        {
+          source: "rss",
+          postCount: 2,
+          latestPostDate: "2026-04-26T10:00:00Z",
+        },
+        {
+          source: "mastodon",
+          postCount: 1,
+          latestPostDate: "2026-04-26T10:00:00Z",
+        },
+        {
+          source: "reddit",
+          postCount: 1,
+          latestPostDate: "2026-04-28T10:00:00Z",
+        },
+      ]);
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+
+  it("can summarize sources after domain and search filters", () => {
+    const fixture = createPostsQueryFixture();
+    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
+
+    try {
+      expect(getSourceSummaries(database, { domain: "example.com", q: "post" })).toEqual([
+        {
+          source: "reddit",
+          postCount: 1,
+          latestPostDate: "2026-04-28T10:00:00Z",
+        },
+        {
+          source: "rss",
+          postCount: 1,
+          latestPostDate: "2026-04-25T10:00:00Z",
+        },
+      ]);
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+});
+
+describe("getDomainSummaries", () => {
+  it("returns URL domain counts from normalized hrefs", () => {
+    const fixture = createPostsQueryFixture();
+    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
+
+    try {
+      expect(getDomainSummaries(database)).toEqual([
+        {
+          domain: "example.com",
+          postCount: 2,
+          urlCount: 3,
+          latestPostDate: "2026-04-28T10:00:00Z",
+        },
+        {
+          domain: "docs.example.org",
+          postCount: 1,
+          urlCount: 1,
+          latestPostDate: "2026-04-26T10:00:00Z",
+        },
+      ]);
+    } finally {
+      database.close();
+      fixture.cleanup();
+    }
+  });
+
+  it("can summarize domains after source and search filters", () => {
+    const fixture = createPostsQueryFixture();
+    const database = openFetchlinksDatabase({ fetchlinksDbPath: fixture.dbPath });
+
+    try {
+      expect(getDomainSummaries(database, { source: "rss", q: "post" })).toEqual([
+        {
+          domain: "docs.example.org",
+          postCount: 1,
+          urlCount: 1,
+          latestPostDate: "2026-04-26T10:00:00Z",
+        },
+        {
+          domain: "example.com",
+          postCount: 1,
+          urlCount: 1,
+          latestPostDate: "2026-04-25T10:00:00Z",
+        },
+      ]);
     } finally {
       database.close();
       fixture.cleanup();
@@ -282,7 +458,7 @@ function createPostsQueryFixture(): Fixture {
       (1, 1, 0, 'https://short.example/a', 'hash-a', 'https://example.com/a'),
       (2, 2, 1, 'https://short.example/b', 'hash-b1', 'https://example.com/unshortened-b'),
       (3, 2, 0, 'https://example.com/direct-b', 'hash-b0', NULL),
-      (4, 4, 0, 'https://example.com/d', 'hash-d', NULL);
+      (4, 4, 0, 'https://docs.example.org/d', 'hash-d', NULL);
   `);
 }
 

--- a/web/src/server/db.ts
+++ b/web/src/server/db.ts
@@ -1,6 +1,11 @@
 import { DatabaseSync } from "node:sqlite";
 
-import type { PostPage, PostUrl } from "../models/read-models";
+import type {
+  DomainSummary,
+  PostPage,
+  PostUrl,
+  SourceSummary,
+} from "../models/read-models";
 import { loadAppConfig, type AppConfig } from "./config";
 
 type DbConfig = Pick<AppConfig, "fetchlinksDbPath">;
@@ -9,6 +14,19 @@ type Env = Partial<Record<string, string | undefined>>;
 
 type CountRow = {
   count: number;
+};
+
+type SqlParameter = number | string;
+
+type PostFilterQuery = {
+  clauses: string[];
+  params: SqlParameter[];
+};
+
+type NormalizedPostFilters = {
+  source?: string;
+  domain?: string;
+  q?: string;
 };
 
 type PostRow = {
@@ -30,7 +48,26 @@ type PostUrlRow = {
   unshortenedUrl: string | null;
 };
 
-export type GetPostsOptions = {
+type SourceSummaryRow = {
+  source: string;
+  postCount: number;
+  latestPostDate: string | null;
+};
+
+type DomainSummaryRow = {
+  domain: string;
+  postCount: number;
+  urlCount: number;
+  latestPostDate: string | null;
+};
+
+export type PostFilters = {
+  source?: string;
+  domain?: string;
+  q?: string;
+};
+
+export type GetPostsOptions = PostFilters & {
   page?: number;
   pageSize?: number;
 };
@@ -86,7 +123,10 @@ export function getPosts(
     DEFAULT_PAGE_SIZE,
     "pageSize",
   );
-  const totalPosts = getPostCount(database);
+  const filters = normalizePostFilters(options);
+  const filterQuery = buildPostFilterQuery(filters);
+  const whereSql = toWhereSql(filterQuery.clauses);
+  const totalPosts = getFilteredPostCount(database, filterQuery);
   const totalPages = Math.ceil(totalPosts / pageSize);
   const postRows = database
     .prepare(`
@@ -99,10 +139,11 @@ export function getPosts(
         date_created AS dateCreated,
         unique_id_string AS uniqueId
       FROM posts
+      ${whereSql}
       ORDER BY date_created DESC, idx DESC
       LIMIT ? OFFSET ?
     `)
-    .all(pageSize, (page - 1) * pageSize) as PostRow[];
+    .all(...filterQuery.params, pageSize, (page - 1) * pageSize) as PostRow[];
   const urlsByPostId = getUrlsByPostId(
     database,
     postRows.map((post) => post.id),
@@ -120,6 +161,82 @@ export function getPosts(
     hasPreviousPage: page > 1,
     hasNextPage: page < totalPages,
   };
+}
+
+export function getSourceSummaries(
+  database: FetchlinksDatabase,
+  filters: PostFilters = {},
+): SourceSummary[] {
+  const filterQuery = buildPostFilterQuery(normalizePostFilters(filters));
+  const rows = database
+    .prepare(`
+      SELECT
+        source,
+        COUNT(*) AS postCount,
+        MAX(date_created) AS latestPostDate
+      FROM posts
+      ${toWhereSql(filterQuery.clauses)}
+      GROUP BY source
+      ORDER BY postCount DESC, source ASC
+    `)
+    .all(...filterQuery.params) as SourceSummaryRow[];
+
+  return rows;
+}
+
+export function getDomainSummaries(
+  database: FetchlinksDatabase,
+  filters: PostFilters = {},
+): DomainSummary[] {
+  const normalizedFilters = normalizePostFilters(filters);
+  const postFilterQuery = buildPostFilterQuery(normalizedFilters, {
+    includeDomain: false,
+  });
+  const clauses = ["url_domains.domain <> ''", ...postFilterQuery.clauses];
+  const params = [...postFilterQuery.params];
+
+  if (normalizedFilters.domain) {
+    clauses.push("url_domains.domain = ?");
+    params.push(normalizedFilters.domain);
+  }
+
+  const rows = database
+    .prepare(`
+      WITH url_domains AS (
+        SELECT
+          post_id AS postId,
+          ${domainSqlExpression("post_urls")} AS domain
+        FROM post_urls
+      )
+      SELECT
+        url_domains.domain,
+        COUNT(DISTINCT url_domains.postId) AS postCount,
+        COUNT(*) AS urlCount,
+        MAX(posts.date_created) AS latestPostDate
+      FROM url_domains
+      INNER JOIN posts ON posts.idx = url_domains.postId
+      ${toWhereSql(clauses)}
+      GROUP BY url_domains.domain
+      ORDER BY postCount DESC, urlCount DESC, url_domains.domain ASC
+    `)
+    .all(...params) as DomainSummaryRow[];
+
+  return rows;
+}
+
+function getFilteredPostCount(
+  database: FetchlinksDatabase,
+  filterQuery: PostFilterQuery,
+): number {
+  const row = database
+    .prepare(`
+      SELECT COUNT(*) AS count
+      FROM posts
+      ${toWhereSql(filterQuery.clauses)}
+    `)
+    .get(...filterQuery.params) as CountRow | undefined;
+
+  return row?.count ?? 0;
 }
 
 function getUrlsByPostId(
@@ -158,6 +275,98 @@ function getUrlsByPostId(
   }
 
   return urlsByPostId;
+}
+
+function buildPostFilterQuery(
+  filters: NormalizedPostFilters,
+  {
+    includeSource = true,
+    includeDomain = true,
+    includeSearch = true,
+  }: {
+    includeSource?: boolean;
+    includeDomain?: boolean;
+    includeSearch?: boolean;
+  } = {},
+): PostFilterQuery {
+  const clauses: string[] = [];
+  const params: SqlParameter[] = [];
+
+  if (includeSource && filters.source) {
+    clauses.push("posts.source = ?");
+    params.push(filters.source);
+  }
+
+  if (includeDomain && filters.domain) {
+    clauses.push(`
+      EXISTS (
+        SELECT 1
+        FROM post_urls domain_urls
+        WHERE domain_urls.post_id = posts.idx
+          AND ${domainSqlExpression("domain_urls")} = ?
+      )
+    `);
+    params.push(filters.domain);
+  }
+
+  if (includeSearch && filters.q) {
+    const pattern = `%${escapeLikeValue(filters.q.toLowerCase())}%`;
+
+    clauses.push(`
+      (
+        LOWER(COALESCE(posts.description, '')) LIKE ? ESCAPE '\\'
+        OR LOWER(posts.source) LIKE ? ESCAPE '\\'
+        OR LOWER(COALESCE(posts.author, '')) LIKE ? ESCAPE '\\'
+        OR LOWER(COALESCE(posts.direct_link, '')) LIKE ? ESCAPE '\\'
+        OR EXISTS (
+          SELECT 1
+          FROM post_urls search_urls
+          WHERE search_urls.post_id = posts.idx
+            AND (
+              LOWER(search_urls.url) LIKE ? ESCAPE '\\'
+              OR LOWER(COALESCE(search_urls.unshortened_url, '')) LIKE ? ESCAPE '\\'
+            )
+        )
+      )
+    `);
+    params.push(pattern, pattern, pattern, pattern, pattern, pattern);
+  }
+
+  return { clauses, params };
+}
+
+function normalizePostFilters(filters: PostFilters): NormalizedPostFilters {
+  const source = normalizeOptionalText(filters.source);
+  const domain = normalizeOptionalText(filters.domain)?.toLowerCase();
+  const q = normalizeOptionalText(filters.q);
+
+  return { source, domain, q };
+}
+
+function normalizeOptionalText(value: string | undefined): string | undefined {
+  const text = value?.trim();
+
+  return text ? text : undefined;
+}
+
+function toWhereSql(clauses: string[]): string {
+  return clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+}
+
+function escapeLikeValue(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("%", "\\%")
+    .replaceAll("_", "\\_");
+}
+
+function domainSqlExpression(tableAlias: string): string {
+  const href = `COALESCE(${tableAlias}.unshortened_url, ${tableAlias}.url)`;
+  const withoutScheme = `CASE WHEN INSTR(${href}, '://') > 0 THEN SUBSTR(${href}, INSTR(${href}, '://') + 3) ELSE ${href} END`;
+  const beforePath = `CASE WHEN INSTR(${withoutScheme}, '/') > 0 THEN SUBSTR(${withoutScheme}, 1, INSTR(${withoutScheme}, '/') - 1) ELSE ${withoutScheme} END`;
+  const beforeQuery = `CASE WHEN INSTR(${beforePath}, '?') > 0 THEN SUBSTR(${beforePath}, 1, INSTR(${beforePath}, '?') - 1) ELSE ${beforePath} END`;
+
+  return `LOWER(CASE WHEN INSTR(${beforeQuery}, '#') > 0 THEN SUBSTR(${beforeQuery}, 1, INSTR(${beforeQuery}, '#') - 1) ELSE ${beforeQuery} END)`;
 }
 
 function normalizePositiveInteger(


### PR DESCRIPTION
## Summary
- add source, domain, and search filtering to getPosts
- add source summary and domain summary queries
- extract URL domains from normalized hrefs using unshortened_url when present
- add GET filter controls for source, domain, and search on the latest posts page
- preserve active filters in pagination links
- expand DB and page tests for source filtering, domain filtering, summaries, search, combined filters, and filtered empty states

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npm audit --audit-level=moderate
- browser checked real DB root page with filter controls
- browser checked source filter: 468 matching posts for InfoSecNews
- browser checked domain filter: 465 matching posts for github.com
- browser checked search filter: 35 matching posts for Chrome
- browser checked combined domain+search filter: 4 matching posts for github.com + Chrome