### PR TITLE
Improve link browsing UI

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,13 +1,19 @@
 :root {
-  --background: #f5f7fb;
-  --foreground: #181816;
-  --muted: #52606d;
-  --subtle: #eef2f7;
+  --background: #f6f7f4;
+  --foreground: #181b19;
+  --muted: #5a635e;
+  --subtle: #eef1ec;
   --panel: #ffffff;
-  --border: #d8dee9;
-  --accent: #167a5b;
-  --accent-strong: #0f5a43;
+  --panel-alt: #fbfcf9;
+  --border: #d8ddd3;
+  --border-strong: #bbc7bd;
+  --accent: #176c5b;
+  --accent-strong: #0b4f42;
+  --accent-soft: #e2f1eb;
+  --link: #0b5d7e;
+  --link-hover: #084865;
   --danger: #a23b3b;
+  --focus: #b66a00;
 }
 
 html {
@@ -42,21 +48,39 @@ a {
   text-decoration: none;
 }
 
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--focus) 55%, transparent);
+  outline-offset: 2px;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
 .shell {
-  width: min(1040px, 100%);
+  width: min(1180px, 100%);
   margin: 0 auto;
-  padding: 32px 24px;
+  padding: 24px;
 }
 
 .page-header {
   width: 100%;
   display: flex;
-  align-items: end;
+  align-items: center;
   justify-content: space-between;
-  gap: 24px;
-  margin-bottom: 24px;
-  padding-bottom: 16px;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding-bottom: 14px;
   border-bottom: 1px solid var(--border);
+}
+
+.page-title {
+  min-width: 0;
 }
 
 .eyebrow {
@@ -67,13 +91,13 @@ a {
 }
 
 h1 {
-  margin-top: 6px;
-  font-size: 32px;
+  margin-top: 4px;
+  font-size: 30px;
   line-height: 1.2;
 }
 
 h2 {
-  font-size: 20px;
+  font-size: 18px;
   line-height: 1.3;
 }
 
@@ -84,16 +108,28 @@ p {
 }
 
 .page-summary {
-  margin-top: 6px;
+  display: grid;
+  gap: 2px;
+  min-width: max-content;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.2;
+  text-align: right;
+}
+
+.page-summary strong {
+  color: var(--foreground);
+  font-size: 22px;
+  line-height: 1;
 }
 
 .filter-bar {
   display: grid;
-  grid-template-columns: minmax(220px, 2fr) minmax(160px, 1fr) minmax(160px, 1fr) auto auto;
+  grid-template-columns: minmax(240px, 2fr) minmax(180px, 1fr) minmax(180px, 1fr) auto;
   gap: 12px;
   align-items: end;
-  margin-bottom: 24px;
-  padding: 16px;
+  margin-bottom: 16px;
+  padding: 12px;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--panel);
@@ -114,12 +150,12 @@ p {
 .filter-bar input,
 .filter-bar select {
   width: 100%;
-  min-height: 38px;
+  min-height: 36px;
   border: 1px solid var(--border);
   border-radius: 6px;
   background: #ffffff;
   color: var(--foreground);
-  font: inherit;
+  text-overflow: ellipsis;
 }
 
 .filter-bar input {
@@ -130,10 +166,15 @@ p {
   padding: 0 8px;
 }
 
+.filter-actions {
+  display: flex;
+  gap: 8px;
+}
+
 .filter-bar button,
 .clear-filters {
   display: inline-flex;
-  min-height: 38px;
+  min-height: 36px;
   align-items: center;
   justify-content: center;
   padding: 0 14px;
@@ -150,6 +191,10 @@ p {
   cursor: pointer;
 }
 
+.filter-bar button:hover {
+  background: var(--accent-strong);
+}
+
 .clear-filters {
   border: 1px solid var(--border);
   background: var(--subtle);
@@ -158,46 +203,62 @@ p {
 
 .post-list {
   display: grid;
-  gap: 16px;
+  gap: 10px;
 }
 
 .post-item,
 .state {
-  padding: 20px;
+  padding: 14px 16px;
   border: 1px solid var(--border);
+  border-left: 3px solid transparent;
   border-radius: 8px;
   background: var(--panel);
 }
 
 .post-item {
   display: grid;
+  gap: 8px;
+}
+
+.post-item:hover {
+  border-left-color: var(--accent);
+  background: var(--panel-alt);
+}
+
+.post-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
   gap: 12px;
 }
 
 .post-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px 12px;
+  gap: 4px 10px;
+  min-width: 0;
   color: var(--muted);
-  font-size: 14px;
+  font-size: 13px;
+  line-height: 1.4;
 }
 
 .post-meta span:not(:last-child)::after {
-  margin-left: 12px;
+  margin-left: 10px;
   color: var(--border);
   content: "/";
 }
 
-.post-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+.post-source {
+  max-width: min(560px, 100%);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.post-actions a,
+.source-link,
 .pagination a {
   display: inline-flex;
-  min-height: 36px;
+  min-height: 32px;
   align-items: center;
   justify-content: center;
   border: 1px solid var(--accent);
@@ -207,29 +268,45 @@ p {
   font-weight: 700;
 }
 
-.post-actions a {
+.source-link {
+  flex: 0 0 auto;
   padding: 0 12px;
 }
 
-.post-actions a:hover,
+.source-link:hover,
 .pagination a:hover {
   background: var(--accent);
   color: #ffffff;
 }
 
+.post-item h2 {
+  max-width: 82ch;
+}
+
 .url-list {
   display: grid;
-  gap: 8px;
-  padding-left: 20px;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--subtle);
   overflow-wrap: anywhere;
+  list-style: none;
+}
+
+.url-list li {
+  display: grid;
+  gap: 2px;
 }
 
 .url-list a {
-  color: var(--accent-strong);
+  color: var(--link);
   font-weight: 700;
   text-decoration: underline;
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
+}
+
+.url-list a:hover {
+  color: var(--link-hover);
 }
 
 .url-original {
@@ -257,7 +334,7 @@ p {
   grid-template-columns: 112px 1fr 112px;
   gap: 12px;
   align-items: center;
-  margin-top: 24px;
+  margin-top: 18px;
   color: var(--muted);
   font-size: 14px;
   text-align: center;
@@ -270,7 +347,7 @@ p {
 
 .pagination span[aria-disabled="true"] {
   display: inline-flex;
-  min-height: 36px;
+  min-height: 32px;
   align-items: center;
   justify-content: center;
   border: 1px solid var(--border);
@@ -279,21 +356,59 @@ p {
   color: var(--muted);
 }
 
+@media (max-width: 900px) {
+  .filter-bar {
+    grid-template-columns: minmax(220px, 1fr) minmax(180px, 1fr);
+  }
+
+  .filter-actions {
+    grid-column: 1 / -1;
+  }
+}
+
 @media (max-width: 640px) {
   .shell {
-    padding: 24px 16px;
+    padding: 18px 14px;
   }
 
   .page-header {
-    display: block;
+    display: grid;
+    gap: 10px;
+  }
+
+  .page-summary {
+    min-width: 0;
+    text-align: left;
   }
 
   h1 {
-    font-size: 28px;
+    font-size: 26px;
   }
 
   .filter-bar {
     grid-template-columns: 1fr;
+  }
+
+  .filter-actions {
+    grid-column: auto;
+  }
+
+  .post-item,
+  .state {
+    padding: 14px;
+  }
+
+  .post-heading {
+    display: grid;
+  }
+
+  .source-link {
+    justify-self: start;
+  }
+
+  .post-source {
+    max-width: 100%;
+    white-space: normal;
   }
 
   .pagination {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -15,6 +15,11 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Fetchlinks",
   description: "A web interface for collected links",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -29,8 +29,9 @@ describe("Home", () => {
       />,
     );
 
-    expect(markup).toContain("75 matching posts");
+    expect(markup).toContain('aria-label="75 matching posts"');
     expect(markup).toContain('name="q"');
+    expect(markup).toContain('aria-label="Filter posts"');
     expect(markup).toContain('value="AI"');
     expect(markup).toContain("reddit (1)");
     expect(markup).toContain("example.com (1)");
@@ -64,7 +65,7 @@ describe("Home", () => {
       />,
     );
 
-    expect(markup).toContain("0 matching posts");
+    expect(markup).toContain('aria-label="0 matching posts"');
     expect(markup).toContain("No posts match the current filters.");
   });
 

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -152,15 +152,19 @@ function PageHeader({
 
   return (
     <header className="page-header">
-      <p className="eyebrow">Fetchlinks</p>
-      <div>
+      <div className="page-title">
+        <p className="eyebrow">Fetchlinks</p>
         <h1>Latest posts</h1>
-        {page ? (
-          <p className="page-summary">
-            {page.totalPosts.toLocaleString("en-US")} {summaryLabel}
-          </p>
-        ) : null}
       </div>
+      {page ? (
+        <p
+          aria-label={`${page.totalPosts.toLocaleString("en-US")} ${summaryLabel}`}
+          className="page-summary"
+        >
+          <strong>{page.totalPosts.toLocaleString("en-US")}</strong>{" "}
+          <span>{summaryLabel}</span>
+        </p>
+      ) : null}
     </header>
   );
 }
@@ -178,7 +182,7 @@ function FilterBar({
   const domainOptions = includeActiveDomain(domains, filters.domain);
 
   return (
-    <form action="/" className="filter-bar" method="get">
+    <form action="/" aria-label="Filter posts" className="filter-bar" method="get">
       <label>
         <span>Search</span>
         <input
@@ -210,12 +214,14 @@ function FilterBar({
           ))}
         </select>
       </label>
-      <button type="submit">Apply</button>
-      {hasActiveFilters(filters) ? (
-        <Link className="clear-filters" href="/">
-          Clear
-        </Link>
-      ) : null}
+      <div className="filter-actions">
+        <button type="submit">Apply</button>
+        {hasActiveFilters(filters) ? (
+          <Link className="clear-filters" href="/">
+            Clear
+          </Link>
+        ) : null}
+      </div>
     </form>
   );
 }
@@ -239,21 +245,28 @@ function EmptyPostsState({ filters, page }: { filters: ActiveFilters; page: Post
 function PostListItem({ post }: { post: PostSummary }) {
   return (
     <article className="post-item">
-      <div className="post-meta">
-        <span>{post.source}</span>
-        {post.author ? <span>{post.author}</span> : null}
-        <time dateTime={post.dateCreated}>{formatPostDate(post.dateCreated)}</time>
-      </div>
-      <h2>{post.description ?? "Untitled post"}</h2>
-      <div className="post-actions">
+      <header className="post-heading">
+        <div className="post-meta">
+          <span className="post-source" title={post.source}>
+            {formatUrlLabel(post.source)}
+          </span>
+          {post.author ? <span>{post.author}</span> : null}
+          <time dateTime={post.dateCreated}>{formatPostDate(post.dateCreated)}</time>
+        </div>
         {post.directLink ? (
-          <a href={post.directLink} rel="noreferrer" target="_blank">
+          <a
+            className="source-link"
+            href={post.directLink}
+            rel="noreferrer"
+            target="_blank"
+          >
             Source post
           </a>
         ) : null}
-      </div>
+      </header>
+      <h2>{post.description ?? "Untitled post"}</h2>
       {post.urls.length > 0 ? (
-        <ul className="url-list">
+        <ul aria-label="Extracted URLs" className="url-list">
           {post.urls.map((url) => (
             <PostUrlItem key={url.id} url={url} />
           ))}


### PR DESCRIPTION
## Summary
- tighten the latest-posts layout for denser scanning
- make the filter bar more compact and responsive
- improve post rows with clearer metadata hierarchy, source URL truncation, and denser URL lists
- add stronger focus-visible states and refined link/button treatment
- add explicit viewport metadata so mobile breakpoints apply
- update page rendering assertions for the accessible filter and count labels

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npm audit --audit-level=moderate
- browser checked real DB desktop layout with no horizontal overflow
- attempted mobile viewport review; added explicit viewport metadata after finding the page reported a wide layout viewport without it