### PR TITLE
Update post tile link layout

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -242,10 +242,8 @@ p {
   line-height: 1.4;
 }
 
-.post-meta span:not(:last-child)::after {
-  margin-left: 10px;
+.post-meta-separator {
   color: var(--border);
-  content: "/";
 }
 
 .post-source {
@@ -253,9 +251,16 @@ p {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  color: var(--accent-strong);
+  font-weight: 700;
 }
 
-.source-link,
+.post-source:hover {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 .pagination a {
   display: inline-flex;
   min-height: 32px;
@@ -268,12 +273,6 @@ p {
   font-weight: 700;
 }
 
-.source-link {
-  flex: 0 0 auto;
-  padding: 0 12px;
-}
-
-.source-link:hover,
 .pagination a:hover {
   background: var(--accent);
   color: #ffffff;
@@ -283,21 +282,27 @@ p {
   max-width: 82ch;
 }
 
-.url-list {
-  display: grid;
-  gap: 6px;
+.post-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 6px;
   padding-top: 8px;
   border-top: 1px solid var(--subtle);
-  overflow-wrap: anywhere;
-  list-style: none;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.4;
 }
 
-.url-list li {
-  display: grid;
-  gap: 2px;
+.post-link-action {
+  display: inline-flex;
+  gap: 6px;
 }
 
-.url-list a {
+.post-link-separator {
+  color: var(--muted);
+}
+
+.post-links a {
   color: var(--link);
   font-weight: 700;
   text-decoration: underline;
@@ -305,15 +310,8 @@ p {
   text-underline-offset: 3px;
 }
 
-.url-list a:hover {
+.post-links a:hover {
   color: var(--link-hover);
-}
-
-.url-original {
-  display: block;
-  margin-top: 2px;
-  color: var(--muted);
-  font-size: 13px;
 }
 
 .state {
@@ -400,10 +398,6 @@ p {
 
   .post-heading {
     display: grid;
-  }
-
-  .source-link {
-    justify-self: start;
   }
 
   .post-source {

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -10,12 +10,16 @@ describe("Home", () => {
 
     expect(markup).toContain("Latest posts");
     expect(markup).toContain("Newest post");
-    expect(markup).toContain("reddit");
     expect(markup).toContain("Grace");
+    expect(markup).toContain('href="https://www.reddit.com/r/test"');
     expect(markup).toContain("Apr 28, 2026, 10:00 AM");
-    expect(markup).toContain("Source post");
-    expect(markup).toContain("example.com/unshortened-b");
-    expect(markup).toContain("via short.example/b");
+    expect(markup).toContain('aria-label="Post links"');
+    expect(markup).toContain("link 1");
+    expect(markup).toContain("link 2");
+    expect(markup).toContain("source");
+    expect(markup).toContain('href="https://example.com/unshortened-b"');
+    expect(markup).toContain('title="via short.example/b"');
+    expect(markup).not.toContain("Source post");
     expect(markup).toContain('href="/?page=2"');
   });
 
@@ -105,7 +109,7 @@ function createPostPage(overrides: Partial<PostPage> = {}): PostPage {
     posts: [
       {
         id: 2,
-        source: "reddit",
+        source: "https://www.reddit.com/r/test",
         author: "Grace",
         description: "Newest post",
         directLink: "https://example.com/source-post",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -247,47 +247,72 @@ function PostListItem({ post }: { post: PostSummary }) {
     <article className="post-item">
       <header className="post-heading">
         <div className="post-meta">
-          <span className="post-source" title={post.source}>
-            {formatUrlLabel(post.source)}
-          </span>
-          {post.author ? <span>{post.author}</span> : null}
-          <time dateTime={post.dateCreated}>{formatPostDate(post.dateCreated)}</time>
-        </div>
-        {post.directLink ? (
           <a
-            className="source-link"
-            href={post.directLink}
+            className="post-source"
+            href={toExternalHref(post.source)}
             rel="noreferrer"
             target="_blank"
+            title={post.source}
           >
-            Source post
+            {getSourceLabel(post)}
           </a>
-        ) : null}
+          <span aria-hidden="true" className="post-meta-separator">
+            /
+          </span>
+          <time dateTime={post.dateCreated}>{formatPostDate(post.dateCreated)}</time>
+        </div>
       </header>
       <h2>{post.description ?? "Untitled post"}</h2>
-      {post.urls.length > 0 ? (
-        <ul aria-label="Extracted URLs" className="url-list">
-          {post.urls.map((url) => (
-            <PostUrlItem key={url.id} url={url} />
+      {post.urls.length > 0 || post.directLink ? (
+        <nav aria-label="Post links" className="post-links">
+          {post.urls.map((url, index) => (
+            <PostLinkAction key={url.id} showSeparator={index > 0}>
+              <PostUrlItem
+                label={post.urls.length === 1 ? "link" : `link ${index + 1}`}
+                url={url}
+              />
+            </PostLinkAction>
           ))}
-        </ul>
+          {post.directLink ? (
+            <PostLinkAction showSeparator={post.urls.length > 0}>
+              <a href={post.directLink} rel="noreferrer" target="_blank">
+                source
+              </a>
+            </PostLinkAction>
+          ) : null}
+        </nav>
       ) : null}
     </article>
   );
 }
 
-function PostUrlItem({ url }: { url: PostUrl }) {
+function PostLinkAction({
+  children,
+  showSeparator,
+}: {
+  children: React.ReactNode;
+  showSeparator: boolean;
+}) {
+  return (
+    <span className="post-link-action">
+      {showSeparator ? <span className="post-link-separator">,</span> : null}
+      {children}
+    </span>
+  );
+}
+
+function PostUrlItem({ label, url }: { label: string; url: PostUrl }) {
   const usesUnshortenedUrl = url.href !== url.originalUrl;
 
   return (
-    <li>
-      <a href={url.href} rel="noreferrer" target="_blank">
-        {formatUrlLabel(url.href)}
-      </a>
-      {usesUnshortenedUrl ? (
-        <span className="url-original">via {formatUrlLabel(url.originalUrl)}</span>
-      ) : null}
-    </li>
+    <a
+      href={url.href}
+      rel="noreferrer"
+      target="_blank"
+      title={usesUnshortenedUrl ? `via ${formatUrlLabel(url.originalUrl)}` : url.href}
+    >
+      {label}
+    </a>
   );
 }
 
@@ -381,6 +406,18 @@ function formatUrlLabel(value: string) {
     return `${url.hostname}${url.pathname}${url.search}`;
   } catch {
     return value;
+  }
+}
+
+function getSourceLabel(post: PostSummary) {
+  return post.author?.trim() || formatUrlLabel(post.source);
+}
+
+function toExternalHref(value: string) {
+  try {
+    return new URL(value).toString();
+  } catch {
+    return `https://${value}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- make the friendly source label clickable to the source URL
- replace extracted URL text with compact link / link 1 labels
- move direct post links into a quiet bottom source action
- remove the large Source post button treatment
- keep separators outside clickable link text
- update rendering tests for the new tile layout

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npm audit --audit-level=moderate
- server-rendered real DB check: Brighttalk card shows friendly source link and link action
- server-rendered real DB check: Reddit card shows link, source and no Source post text