### PR TITLE
Align post tile action row

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -285,12 +285,21 @@ p {
 .post-links {
   display: flex;
   flex-wrap: wrap;
-  gap: 0 6px;
+  gap: 8px 16px;
+  align-items: center;
+  justify-content: space-between;
   padding-top: 8px;
   border-top: 1px solid var(--subtle);
   color: var(--muted);
   font-size: 14px;
   line-height: 1.4;
+}
+
+.post-url-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 6px;
+  min-width: 0;
 }
 
 .post-link-action {
@@ -312,6 +321,10 @@ p {
 
 .post-links a:hover {
   color: var(--link-hover);
+}
+
+.post-source-action {
+  margin-left: auto;
 }
 
 .state {

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -14,8 +14,10 @@ describe("Home", () => {
     expect(markup).toContain('href="https://www.reddit.com/r/test"');
     expect(markup).toContain("Apr 28, 2026, 10:00 AM");
     expect(markup).toContain('aria-label="Post links"');
+    expect(markup).toContain('class="post-url-actions"');
     expect(markup).toContain("link 1");
     expect(markup).toContain("link 2");
+    expect(markup).toContain('class="post-source-action"');
     expect(markup).toContain("source");
     expect(markup).toContain('href="https://example.com/unshortened-b"');
     expect(markup).toContain('title="via short.example/b"');
@@ -43,6 +45,23 @@ describe("Home", () => {
     expect(markup).toContain(
       'href="/?source=reddit&amp;domain=example.com&amp;q=AI&amp;page=2"',
     );
+  });
+
+  it("renders a single extracted URL as link 1", () => {
+    const page = createPostPage();
+    const [post] = page.posts;
+    const markup = renderToStaticMarkup(
+      <LatestPostsView
+        result={createReadyResult({
+          page: createPostPage({
+            posts: [{ ...post, urls: [post.urls[0]], directLink: null }],
+          }),
+        })}
+      />,
+    );
+
+    expect(markup).toContain(">link 1</a>");
+    expect(markup).not.toContain(">link</a>");
   });
 
   it("renders an empty state when no posts exist", () => {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -265,20 +265,24 @@ function PostListItem({ post }: { post: PostSummary }) {
       <h2>{post.description ?? "Untitled post"}</h2>
       {post.urls.length > 0 || post.directLink ? (
         <nav aria-label="Post links" className="post-links">
-          {post.urls.map((url, index) => (
-            <PostLinkAction key={url.id} showSeparator={index > 0}>
-              <PostUrlItem
-                label={post.urls.length === 1 ? "link" : `link ${index + 1}`}
-                url={url}
-              />
-            </PostLinkAction>
-          ))}
+          {post.urls.length > 0 ? (
+            <span className="post-url-actions">
+              {post.urls.map((url, index) => (
+                <PostLinkAction key={url.id} showSeparator={index > 0}>
+                  <PostUrlItem label={`link ${index + 1}`} url={url} />
+                </PostLinkAction>
+              ))}
+            </span>
+          ) : null}
           {post.directLink ? (
-            <PostLinkAction showSeparator={post.urls.length > 0}>
-              <a href={post.directLink} rel="noreferrer" target="_blank">
-                source
-              </a>
-            </PostLinkAction>
+            <a
+              className="post-source-action"
+              href={post.directLink}
+              rel="noreferrer"
+              target="_blank"
+            >
+              source
+            </a>
           ) : null}
         </nav>
       ) : null}


### PR DESCRIPTION
## Summary
- always label extracted post URLs as numbered links
- group URL actions on the left and push the source action to the right
- cover the single-link label behavior in page rendering tests

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- npm audit --audit-level=moderate
- real DB server-rendered HTML check for link 1 and right-side source action