### PR TITLE
Add VM deployment examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,49 @@ npm run dev
 ```
 
 See `web/README.md` for runtime, environment, and validation commands.
+
+## Deployment
+
+The example VM deployment runs the Next.js app with systemd on `127.0.0.1:3000` and exposes it through nginx. The example files live under `deploy/` and assume:
+
+- The repository is deployed at `/opt/fetchlinks_webapp`.
+- The service user and group are both `fetchlinks`.
+- The SQLite database is readable at `/var/lib/fetchlinks/fetchlinks.db`.
+- The public hostname is `fetchlinks.example.com`.
+- npm is available at `/usr/bin/npm`.
+
+Adjust those values for the target VM before installing the files.
+
+```bash
+sudo install -d -o fetchlinks -g fetchlinks /opt/fetchlinks_webapp
+sudo -u fetchlinks git clone https://github.com/poptart-sommelier/fetchlinks_webapp.git /opt/fetchlinks_webapp
+cd /opt/fetchlinks_webapp
+
+sudo -u fetchlinks npm --prefix /opt/fetchlinks_webapp/web ci
+sudo -u fetchlinks npm --prefix /opt/fetchlinks_webapp/web run validate:production
+
+sudo install -d -m 0750 -o root -g fetchlinks /etc/fetchlinks
+sudo install -m 0640 -o root -g fetchlinks deploy/systemd/fetchlinks-web.env.example /etc/fetchlinks/web.env
+sudoedit /etc/fetchlinks/web.env
+
+sudo install -m 0644 deploy/systemd/fetchlinks-web.service /etc/systemd/system/fetchlinks-web.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now fetchlinks-web
+sudo systemctl status fetchlinks-web
+
+sudo install -m 0644 deploy/nginx/fetchlinks-web.conf.example /etc/nginx/sites-available/fetchlinks-web
+sudo ln -s /etc/nginx/sites-available/fetchlinks-web /etc/nginx/sites-enabled/fetchlinks-web
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+For updates after the initial install:
+
+```bash
+sudo -u fetchlinks git -C /opt/fetchlinks_webapp pull --ff-only
+sudo -u fetchlinks npm --prefix /opt/fetchlinks_webapp/web ci
+sudo -u fetchlinks npm --prefix /opt/fetchlinks_webapp/web run validate:production
+sudo systemctl restart fetchlinks-web
+```
+
+`FETCHLINKS_DB` must be an absolute path in `/etc/fetchlinks/web.env`, and the `fetchlinks` service user must be able to read the database and its parent directories. The webapp opens the database read-only.

--- a/deploy/nginx/fetchlinks-web.conf.example
+++ b/deploy/nginx/fetchlinks-web.conf.example
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name fetchlinks.example.com;
+
+    access_log /var/log/nginx/fetchlinks-web.access.log;
+    error_log /var/log/nginx/fetchlinks-web.error.log;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+}

--- a/deploy/systemd/fetchlinks-web.env.example
+++ b/deploy/systemd/fetchlinks-web.env.example
@@ -1,0 +1,6 @@
+# Example: /etc/fetchlinks/web.env
+# The systemd service reads this file with EnvironmentFile=.
+
+NODE_ENV=production
+NEXT_TELEMETRY_DISABLED=1
+FETCHLINKS_DB=/var/lib/fetchlinks/fetchlinks.db

--- a/deploy/systemd/fetchlinks-web.service
+++ b/deploy/systemd/fetchlinks-web.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Fetchlinks Next.js web UI
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=fetchlinks
+Group=fetchlinks
+WorkingDirectory=/opt/fetchlinks_webapp/web
+EnvironmentFile=/etc/fetchlinks/web.env
+ExecStart=/usr/bin/npm run start -- --hostname 127.0.0.1 --port 3000
+Restart=on-failure
+RestartSec=5
+KillSignal=SIGTERM
+TimeoutStopSec=30
+SyslogIdentifier=fetchlinks-web
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+
+[Install]
+WantedBy=multi-user.target

--- a/web/README.md
+++ b/web/README.md
@@ -37,3 +37,5 @@ To check production mode manually against a real database:
 FETCHLINKS_DB=/absolute/path/to/fetchlinks.db npm run build
 FETCHLINKS_DB=/absolute/path/to/fetchlinks.db npm run start -- --hostname 127.0.0.1 --port 3000
 ```
+
+VM deployment examples for systemd and nginx are documented in the repository root README.


### PR DESCRIPTION
## Summary
- add example systemd environment and service files for the Next.js web UI
- add an example nginx reverse proxy config for localhost production serving
- document initial VM install, update commands, and FETCHLINKS_DB guidance

## Validation
- npm run validate:production
- npm audit --audit-level=moderate
- git diff --check
- deployment config values reviewed with rg

Note: nginx is not installed in this workspace, so nginx -t was skipped. systemd-analyze verify hung in this environment; the unit file was reviewed directly and kept as a real .service file for target-VM validation.